### PR TITLE
Add infrastructure filtering by hex selection on impact map

### DIFF
--- a/src/lib/components/impactmap/ImpactMapControls.svelte
+++ b/src/lib/components/impactmap/ImpactMapControls.svelte
@@ -49,20 +49,20 @@
 		if (!impactMapState.dataMapKey || !impactDataMap[impactMapState.dataMapKey]) {
 			return null;
 		}
-		
+
 		const data = impactDataMap[impactMapState.dataMapKey];
 		const metaInfo = data.meta_info;
 		const styleStops = data.data_info.style_stops;
-		
+
 		if (!metaInfo.legend_labels || !styleStops) {
 			return null;
 		}
-		
+
 		// Get color palette
 		const colorScale = metaInfo.color_scale;
 		const reverse = metaInfo.reverse_color_scale;
 		const palette = reverse ? [...palettes[colorScale]].reverse() : palettes[colorScale];
-		
+
 		return {
 			labels: metaInfo.legend_labels,
 			colors: palette,
@@ -109,7 +109,6 @@
 		</div>
 	</div>
 
-
 	<!-- Destination Type Menu -->
 	<div>
 		<p class="font-bold">
@@ -136,21 +135,23 @@
 
 	<!-- Legend -->
 	{#if legendData}
-		<div class="mt-6 pt-4 border-t border-gray-300">
-			<p class="font-bold mb-3">Legend</p>
+		<div class="mt-6 border-t border-gray-300 pt-4">
+			<p class="mb-3 font-bold">Legend</p>
 			<div class="space-y-2">
 				<!-- Legend gradient bar -->
-				<div class="relative h-6 rounded" style="background: linear-gradient(to right, {legendData.colors.join(', ')});">
+				<div
+					class="relative h-6 rounded"
+					style="background: linear-gradient(to right, {legendData.colors.join(', ')});">
 				</div>
-				
+
 				<!-- Legend labels -->
-				<div class="flex justify-between text-sm font-mono">
+				<div class="flex justify-between font-mono text-sm">
 					<span>{legendData.labels[0]}</span>
 					<span>{legendData.labels[1]}</span>
 				</div>
-				
+
 				<!-- Legend values (style stops) -->
-				<div class="flex justify-between text-xs text-gray-600 font-mono">
+				<div class="flex justify-between font-mono text-xs text-gray-600">
 					<span>{legendData.stops[0]}{legendData.unit}</span>
 					<span>{legendData.stops[1]}</span>
 					<span>{legendData.stops[2]}</span>

--- a/src/lib/services/impactmap/MapController.svelte.js
+++ b/src/lib/services/impactmap/MapController.svelte.js
@@ -38,11 +38,17 @@ export class MapController {
 		});
 
 		// Setup layer managers
-		this.hexLayerManager = new HexLayerManager(this.map);
 		this.rasterLayerManager = new RasterLayerManager(this.map);
 		this.bridgeLayerManager = new BridgeLayerManager(this.map);
 		this.healthLayerManager = new HealthLayerManager(this.map);
 		this.eduLayerManager = new EduLayerManager(this.map);
+
+		// Initialize hex layer manager with references to other managers for filtering
+		this.hexLayerManager = new HexLayerManager(this.map, {
+			bridgeLayerManager: this.bridgeLayerManager,
+			healthLayerManager: this.healthLayerManager,
+			eduLayerManager: this.eduLayerManager
+		});
 
 		// Setup event handlers
 		this.setupEventHandlers();
@@ -86,6 +92,19 @@ export class MapController {
 			// Setup click handlers
 			this.map.on('click', 'hex-layer', (e) => {
 				this.hexLayerManager.handleHexClick(e);
+			});
+
+			// Reset filters when clicking outside of hex areas
+			this.map.on('click', (e) => {
+				// Check if we're clicking on a hex
+				const hexFeatures = this.map.queryRenderedFeatures(e.point, {
+					layers: ['hex-layer']
+				});
+
+				// If no hex was clicked and we're in filter mode, reset filters
+				if (hexFeatures.length === 0 && impactMapState.filterMode) {
+					this.hexLayerManager.resetInfrastructureFilter();
+				}
 			});
 
 			// Setup hover handlers for hex

--- a/src/lib/services/impactmap/RasterLayerManager.svelte.js
+++ b/src/lib/services/impactmap/RasterLayerManager.svelte.js
@@ -43,19 +43,22 @@ export class RasterLayerManager {
 
 		// Add new layer behind waterway layer
 		console.log('Adding raster layer');
-		this.map.addLayer({
-			id: 'raster-layer',
-			type: 'raster',
-			source: 'raster-source',
-			minzoom: 0,
-			maxzoom: 22,
-			paint: {
-				'raster-color': colorExpression,
-				'raster-color-mix': [255, 0, 0, 0],
-				'raster-color-range': [0, 255],
-				'raster-opacity': ['interpolate', ['linear'], ['zoom'], 0, 0.8, 8, 0.8, 8.2, 0]
-			}
-		}, 'waterway');
+		this.map.addLayer(
+			{
+				id: 'raster-layer',
+				type: 'raster',
+				source: 'raster-source',
+				minzoom: 0,
+				maxzoom: 22,
+				paint: {
+					'raster-color': colorExpression,
+					'raster-color-mix': [255, 0, 0, 0],
+					'raster-color-range': [0, 255],
+					'raster-opacity': ['interpolate', ['linear'], ['zoom'], 0, 0.8, 8, 0.8, 8.2, 0]
+				}
+			},
+			'waterway'
+		);
 	}
 
 	cleanupExistingLayer() {

--- a/src/lib/utils/colorPalettes.js
+++ b/src/lib/utils/colorPalettes.js
@@ -39,10 +39,10 @@ export const palettes = {
 	rdylgn: ['#d7191c', '#fdae61', '#ffffbf', '#a6d96a', '#1a9641'],
 	spectral: ['#d7191c', '#fdae61', '#ffffbf', '#abdda4', '#2b83ba'],
 	// custom
-	salmonaqua: ["#e27c7c", "#6d4b4b", "#333333", "#466964", "#6cd4c5"],
-	orangepurple: ["#ffb400", "#a57c1b", "#363445", "#5e569b", "#9080ff"],
-	blueyellow: ["#115f9a", "#22a7f0", "#76c68f", "#c9e52f", "#d0f400"],
-	
+	salmonaqua: ['#e27c7c', '#6d4b4b', '#333333', '#466964', '#6cd4c5'],
+	orangepurple: ['#ffb400', '#a57c1b', '#363445', '#5e569b', '#9080ff'],
+	blueyellow: ['#115f9a', '#22a7f0', '#76c68f', '#c9e52f', '#d0f400'],
+
 	// Modern matte sequential palettes
 	stoplight: ['#c85a5a', '#e07a56', '#e6b366', '#a8c470', '#5f8a5f'],
 	mattecoral: ['#f4e4e1', '#e8b4a0', '#d4795f', '#b85450', '#8b2f47'],
@@ -53,13 +53,55 @@ export const palettes = {
 	terracotta: ['#faf6f3', '#f0ddd1', '#deb5a0', '#c8886f', '#a8573f'],
 	modernimpact: ['#7dd3c7', '#5bc5a8', '#42b883', '#2ca25f', '#1d7a3f'],
 
-
 	// cyclical
 	rainbow: ['#6e40aa', '#ff5e63', '#aff05b', '#1ac7c2', '#6e40aa'],
 	sinebow: ['#ff4040', '#7fee11', '#00bfbf', '#7f11ee', '#ff4040'],
 	// categorical
-	tableau10: [ '#4e79a7', '#f28e2c', '#e15759', '#76b7b2', '#59a14f', '#edc949', '#af7aa1', '#ff9da7', '#9c755f', '#bab0ab' ],
-	category10: [ '#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf' ],
-	pastel: [ '#fbb4ae', '#b3cde3', '#ccebc5', '#decbe4', '#fed9a6', '#ffffcc', '#e5d8bd', '#fddaec', '#f2f2f2' ],
-	violetocean: [ '#93ECDD', '#7DD6E0', '#6DC0DE', '#66A9DA', '#5493D9', '#507CD4', '#5E60C7', '#6043C0', '#6A11B1', '#9F237E' ]
+	tableau10: [
+		'#4e79a7',
+		'#f28e2c',
+		'#e15759',
+		'#76b7b2',
+		'#59a14f',
+		'#edc949',
+		'#af7aa1',
+		'#ff9da7',
+		'#9c755f',
+		'#bab0ab'
+	],
+	category10: [
+		'#1f77b4',
+		'#ff7f0e',
+		'#2ca02c',
+		'#d62728',
+		'#9467bd',
+		'#8c564b',
+		'#e377c2',
+		'#7f7f7f',
+		'#bcbd22',
+		'#17becf'
+	],
+	pastel: [
+		'#fbb4ae',
+		'#b3cde3',
+		'#ccebc5',
+		'#decbe4',
+		'#fed9a6',
+		'#ffffcc',
+		'#e5d8bd',
+		'#fddaec',
+		'#f2f2f2'
+	],
+	violetocean: [
+		'#93ECDD',
+		'#7DD6E0',
+		'#6DC0DE',
+		'#66A9DA',
+		'#5493D9',
+		'#507CD4',
+		'#5E60C7',
+		'#6043C0',
+		'#6A11B1',
+		'#9F237E'
+	]
 };

--- a/src/lib/utils/state.svelte.js
+++ b/src/lib/utils/state.svelte.js
@@ -54,7 +54,12 @@ const impactMapState = $state({
 	dataName: 'rwi',
 	satelliteImagery: false,
 	clickedData: {},
-	dataMapKey: 'Relative Wealth Index' // Key to the selected data in impactDataMap
+	dataMapKey: 'Relative Wealth Index', // Key to the selected data in impactDataMap
+	selectedHexData: null, // Currently selected hex data from API
+	filterMode: false, // Whether infrastructure filtering is active
+	highlightedBridges: [], // Array of bridge IDs to highlight
+	highlightedHealthFacilities: [], // Array of health facility IDs to highlight
+	highlightedEducationFacilities: [] // Array of education facility IDs to highlight
 });
 
 export {

--- a/src/routes/api/hex-areas/+server.js
+++ b/src/routes/api/hex-areas/+server.js
@@ -1,0 +1,121 @@
+import { json } from '@sveltejs/kit';
+import pg from 'pg';
+import { env } from '$env/dynamic/private';
+
+/** @type {import('./$types').RequestHandler} */
+export async function GET({ url, platform }) {
+	try {
+		// Get database connection string
+		const connectionString = platform?.env?.DATABASE_URL || env.DATABASE_URL;
+
+		// Require a database connection
+		if (!connectionString) {
+			return json(
+				{
+					error: 'Database connection missing',
+					details: 'No connection string provided'
+				},
+				{ status: 500 }
+			);
+		}
+
+		// Parse query parameters
+		const hexID = url.searchParams.get('hexID');
+
+		if (!hexID) {
+			return json(
+				{
+					error: 'Missing hexID parameter',
+					details: 'hexID query parameter is required'
+				},
+				{ status: 400 }
+			);
+		}
+
+		try {
+			// Create client and connect
+			const client = new pg.Client({
+				connectionString,
+				statement_timeout: 30000,
+				connectionTimeoutMillis: 30000
+			});
+
+			// Proper error handling for connection
+			try {
+				await client.connect();
+			} catch (connectError) {
+				console.error('Failed to connect to database:', connectError);
+				return json(
+					{
+						error: 'Database connection failed',
+						details: connectError.message
+					},
+					{ status: 500 }
+				);
+			}
+
+			// Check if hex_areas table exists
+			const tableCheckQuery = `
+                SELECT EXISTS (
+                    SELECT FROM information_schema.tables 
+                    WHERE table_name = 'hex_areas'
+                );
+            `;
+
+			const tableExists = await client.query(tableCheckQuery);
+
+			if (!tableExists.rows[0].exists) {
+				console.warn('hex_areas table does not exist');
+				return json(
+					{
+						error: 'Table not found',
+						details: 'The hex_areas table does not exist in the database'
+					},
+					{ status: 500 }
+				);
+			}
+
+			// Query for the specific hex by hexID
+			const query = `
+                SELECT * FROM hex_areas 
+                WHERE h3_index = $1
+            `;
+
+			// Execute the query with parameterized input for security
+			const result = await client.query(query, [hexID]);
+			await client.end();
+
+			// Check if we found the hex
+			if (result.rows.length === 0) {
+				return json(
+					{
+						error: 'Hex not found',
+						details: `No hex found with ID: ${hexID}`
+					},
+					{ status: 404 }
+				);
+			}
+
+			return json(result.rows[0]);
+		} catch (dbError) {
+			console.error('Database error:', dbError);
+			// Return error for client to handle
+			return json(
+				{
+					error: 'Database error',
+					details: dbError.message
+				},
+				{ status: 500 }
+			);
+		}
+	} catch (error) {
+		console.error('Server error:', error);
+		return json(
+			{
+				error: 'Server error',
+				details: error.message
+			},
+			{ status: 500 }
+		);
+	}
+}


### PR DESCRIPTION
Implements infrastructure filtering on the impact map by allowing users to click a hex, which queries the backend for related infrastructure (bridges, health, and education facilities) and highlights them on the map. Adds a new API endpoint for hex area data, updates state management to track selected hex and highlighted infrastructure, and extends layer managers to support highlight and reset operations. Refactors layer initialization for consistency and improves legend and palette formatting.